### PR TITLE
Autoconf: fix references to external rules

### DIFF
--- a/Autoconf.JSON-tmLanguage
+++ b/Autoconf.JSON-tmLanguage
@@ -951,7 +951,7 @@
                         "1": { "name": "punctuation.definition.logical-expression.shell" }
                     },
                     "patterns": [
-                        { "include": "source.shell.logical-expression" },
+                        { "include": "source.shell#logical-expression" },
                         { "include": "$self" }
                     ]
                 },
@@ -1002,7 +1002,7 @@
         },
 
         "shell-string": {
-            "comment": "This is a copy of #string from source.shell so that we can include our doctored #shell-interpolation before source.shell.interpolation",
+            "comment": "This is a copy of #string from source.shell so that we can include our doctored #shell-interpolation before source.shell#interpolation",
             "patterns": [
                 {
                     "name": "string.quoted.double.shell",
@@ -1019,9 +1019,9 @@
                             "match": "\\\\[\\$`\"\\\\\\n]",
                             "name": "constant.character.escape.shell"
                         },
-                        { "include": "source.shell.variable" },
+                        { "include": "source.shell#variable" },
                         { "include": "#shell-interpolation" },
-                        { "include": "source.shell.interpolation" }
+                        { "include": "source.shell#interpolation" }
                     ]
                 }
             ]
@@ -1098,9 +1098,9 @@
                                 "1": { "name": "keyword.control.shell" }
                             },
                             "patterns": [
-                                { "include": "source.shell.comment" },
+                                { "include": "source.shell#comment" },
                                 { "include": "#shell-case-clause" },
-                                { "include": "source.shell.case-clause" },
+                                { "include": "source.shell#case-clause" },
                                 { "include": "$self" }
                             ]
                         },
@@ -1182,12 +1182,12 @@
                                     "name": "punctuation.separator.pipe-sign.shell"
                                 },
                                 { "include": "#shell-string" },
-                                { "include": "source.shell.string" },
-                                { "include": "source.shell.variable" },
+                                { "include": "source.shell#string" },
+                                { "include": "source.shell#variable" },
                                 { "include": "#shell-interpolation" },
-                                { "include": "source.shell.interpolation" },
+                                { "include": "source.shell#interpolation" },
                                 { "include": "#shell-pathname" },
-                                { "include": "source.shell.pathname" }
+                                { "include": "source.shell#pathname" }
                             ]
                         },
                         {

--- a/Autoconf.tmLanguage
+++ b/Autoconf.tmLanguage
@@ -2004,11 +2004,11 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>source.shell.string</string>
+									<string>source.shell#string</string>
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>source.shell.variable</string>
+									<string>source.shell#variable</string>
 								</dict>
 								<dict>
 									<key>include</key>
@@ -2016,7 +2016,7 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>source.shell.interpolation</string>
+									<string>source.shell#interpolation</string>
 								</dict>
 								<dict>
 									<key>include</key>
@@ -2024,7 +2024,7 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>source.shell.pathname</string>
+									<string>source.shell#pathname</string>
 								</dict>
 							</array>
 						</dict>
@@ -2072,7 +2072,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>source.shell.logical-expression</string>
+							<string>source.shell#logical-expression</string>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -2449,7 +2449,7 @@
 							<array>
 								<dict>
 									<key>include</key>
-									<string>source.shell.comment</string>
+									<string>source.shell#comment</string>
 								</dict>
 								<dict>
 									<key>include</key>
@@ -2457,7 +2457,7 @@
 								</dict>
 								<dict>
 									<key>include</key>
-									<string>source.shell.case-clause</string>
+									<string>source.shell#case-clause</string>
 								</dict>
 								<dict>
 									<key>include</key>
@@ -2582,7 +2582,7 @@
 		<key>shell-string</key>
 		<dict>
 			<key>comment</key>
-			<string>This is a copy of #string from source.shell so that we can include our doctored #shell-interpolation before source.shell.interpolation</string>
+			<string>This is a copy of #string from source.shell so that we can include our doctored #shell-interpolation before source.shell#interpolation</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -2618,7 +2618,7 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>source.shell.variable</string>
+							<string>source.shell#variable</string>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -2626,7 +2626,7 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>source.shell.interpolation</string>
+							<string>source.shell#interpolation</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
While trying to use the Autoconf grammar in Linguist (turns out we can't use it after all since it's GPL v3), our compiler detected that some of the includes have broken references to external rules. This pull request fixes it.